### PR TITLE
before_filter->before_action

### DIFF
--- a/lib/menu_builder/controller.rb
+++ b/lib/menu_builder/controller.rb
@@ -11,7 +11,7 @@ module MenuBuilder
       def menu_items(*items)
         options = items.extract_options!
 
-        before_filter(options) do |controller|
+        before_action(options) do |controller|
           controller.instance_variable_set('@menu_items', items)
         end
       end


### PR DESCRIPTION
Fixes: `DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.`
